### PR TITLE
Fix demo Validating Transaction; user_id was missing

### DIFF
--- a/demo/src/platform.js
+++ b/demo/src/platform.js
@@ -86,6 +86,7 @@ export class PlatformAPI {
             token,
             ip: "127.0.0.1", // @todo: change when IPv6 is fully supported
             client: "superagent",
+            user_id: userId,
           })
         )
     )


### PR DESCRIPTION
The demo Platform API was broken, as the `/claim/${mode}/validate` API call requires the `user_id` and it's missing. 
